### PR TITLE
Adding matplotlib to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ keras>=2.2.4
 numpy>=1.15.2
 tqdm>=4.28.1
 scikit-learn>=0.20.0
+matplotlib>=3.0.2
+


### PR DESCRIPTION
Adding matplotlib requirement (3.0.2 version works for me).
Also added a trailing newline character at the end.